### PR TITLE
adding the firewall modules to their own repo

### DIFF
--- a/modules/network-firewall-rules-egress/README.md
+++ b/modules/network-firewall-rules-egress/README.md
@@ -1,0 +1,55 @@
+<!-- BEGIN_TF_DOCS -->
+# Terraform Module for - network-firewall-rules-egress
+# Example terragrunt.hcl inputs 
+```hcl
+inputs = {
+  name        = "cc-egress-notprod-nfw-base-rules"
+  description = "cc-egress-notprod-nfw-base-rules"
+  account_id  = "example-aws-account-id"
+  vpc_id      = "vpc-example-id"
+  network_firewall_name = "cc-egress-notprod-nfw"
+  network_firewall_policy_name = "cc-egress-notprod-nfw-policy"
+  cidr_input  = "172.16.0.0/16"    
+  whitelisted_domains = file("./whitelisted-domains.txt")  
+  aws_managed_rule_groups = file("./aws_managed_rule_groups.txt")      
+  aws_region    = local.aws_region
+  tags = {
+    Name = "cc-networking-${get_env("env_name", "")}"
+  }
+}
+```
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+## Requirements
+
+No requirements.
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_networkfirewall_firewall.existing_firewall](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_firewall) | resource |
+| [aws_networkfirewall_firewall_policy.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_firewall_policy) | resource |
+| [aws_networkfirewall_rule_group.allow_domains_for_nonprod_01](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_rule_group) | resource |
+| [aws_networkfirewall_firewall.existing_firewall](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/networkfirewall_firewall) | data source |
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | Network Firewall Account-id | `string` | n/a | yes |
+| <a name="input_aws_managed_rule_groups"></a> [aws\_managed\_rule\_groups](#input\_aws\_managed\_rule\_groups) | Network Firewall - A list of AWS maanged stateful rule group arns | `string` | n/a | yes |
+| <a name="input_home_net_cidr_ranges"></a> [home\_net\_cidr\_ranges](#input\_home\_net\_cidr\_ranges) | A set of CIDR ranges used fro the `HOME_NET` rule variable. | `set(string)` | n/a | yes |
+| <a name="input_network_firewall_name"></a> [network\_firewall\_name](#input\_network\_firewall\_name) | Network Firewall name to be supplied | `string` | n/a | yes |
+| <a name="input_network_firewall_policy_name"></a> [network\_firewall\_policy\_name](#input\_network\_firewall\_policy\_name) | Network Firewall Policy name to be supplied | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to the resources. | `map(string)` | `{}` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC assocaited with Network Firewall | `string` | n/a | yes |
+| <a name="input_whitelisted_domains"></a> [whitelisted\_domains](#input\_whitelisted\_domains) | Network Firewall - whitelisted domains file | `string` | n/a | yes |
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_firewall_policy"></a> [firewall\_policy](#output\_firewall\_policy) | n/a |
+
+<!-- END_TF_DOCS -->

--- a/modules/network-firewall-rules-egress/custom_firewall_rule_group.tf
+++ b/modules/network-firewall-rules-egress/custom_firewall_rule_group.tf
@@ -1,0 +1,28 @@
+resource "aws_networkfirewall_rule_group" "allow_domains_for_nonprod_01" {
+  capacity    = 2000
+  name        = "egress-allowed-domainlist-to-internet-01"
+  description = "Allow egress internet access for Non-Production environment"
+  type        = "STATEFUL"
+  rule_group {
+    stateful_rule_options {
+      rule_order = "STRICT_ORDER"
+    }
+    rule_variables {
+      ip_sets {
+        key = "HOME_NET"
+        ip_set {
+          definition = var.home_net_cidr_ranges
+        }
+      }
+    }
+    rules_source {
+      rules_source_list {
+        generated_rules_type = "ALLOWLIST"
+        target_types         = ["HTTP_HOST", "TLS_SNI"]
+        targets = [
+          for line in split("\n", (var.whitelisted_domains)) : trim(line, " \r")
+        ]
+      }
+    }
+  }
+}

--- a/modules/network-firewall-rules-egress/main.tf
+++ b/modules/network-firewall-rules-egress/main.tf
@@ -1,0 +1,89 @@
+###############################################
+# Importing the already existing nfw #
+###############################################
+data "aws_networkfirewall_firewall" "existing_firewall" {
+  name = var.network_firewall_name # "your-existing-firewall-name" imported using terragrunt as it was created using LZA
+}
+
+# Imported the existing NFW below as it was created using LZA
+# example:
+# terragrunt import aws_networkfirewall_firewall.existing_firewall arn:aws:network-firewall:eu-west-2:<aws-account-id>:firewall/<existing-nfw-name>
+
+import {
+  to = aws_networkfirewall_firewall.existing_firewall
+  id = "arn:aws:network-firewall:eu-west-2:${var.account_id}:firewall/${var.network_firewall_name}"
+}
+
+resource "aws_networkfirewall_firewall" "existing_firewall" {
+  name                = var.network_firewall_name ## Existing firewall name
+  vpc_id              = var.vpc_id                ## Use the existing VPC ID
+  firewall_policy_arn = aws_networkfirewall_firewall_policy.policy.arn
+
+  # Subnet mappings (use the existing subnets here)
+  dynamic "subnet_mapping" {
+    for_each = data.aws_networkfirewall_firewall.existing_firewall.subnet_mapping
+    content {
+      subnet_id = subnet_mapping.value.subnet_id
+    }
+  }
+  ## Keeping the old tags when it was created first time
+  tags = {
+    "Accelerator" = "AWSAccelerator"
+    "Name"        = var.network_firewall_name
+  }
+  # Add other necessary attributes here
+}
+
+################
+## nfw-policy  #
+################
+
+# Reading rule groups from text file supplied
+locals {
+  rule_group_arns = split("\n", trimspace(var.aws_managed_rule_groups))
+}
+
+resource "aws_networkfirewall_firewall_policy" "policy" {
+  name = var.network_firewall_policy_name
+
+  firewall_policy {
+    # Reference AWS managed or custom stateful rule groups
+
+    # Specify stateful default actions
+    stateful_default_actions = [
+      #  "aws:drop_established", 
+      "aws:alert_established"
+    ]
+
+    # Configure stateful engine options
+    stateful_engine_options {
+      rule_order = "STRICT_ORDER" # Options: "STRICT_ORDER" or "DEFAULT_ACTION_ORDER"
+    }
+
+    dynamic "stateful_rule_group_reference" {
+      for_each = local.rule_group_arns
+
+      content {
+        resource_arn = "arn:aws:network-firewall:eu-west-2:aws-managed:stateful-rulegroup/${stateful_rule_group_reference.value}"
+        priority     = 200 + index(local.rule_group_arns, stateful_rule_group_reference.value) + 1
+      }
+    }
+
+    # custom rules defined by core-cloud-platform
+    stateful_rule_group_reference {
+      resource_arn = aws_networkfirewall_rule_group.allow_domains_for_nonprod_01.arn
+      priority     = 250
+    }
+
+    # Define the stateless default actions explicitly
+    stateless_default_actions = ["aws:forward_to_sfe"]
+
+    # Define the stateless fragment default actions explicitly
+    stateless_fragment_default_actions = ["aws:forward_to_sfe"]
+  }
+
+  tags = {
+    Name = var.network_firewall_policy_name
+  }
+}
+

--- a/modules/network-firewall-rules-egress/outputs.tf
+++ b/modules/network-firewall-rules-egress/outputs.tf
@@ -1,0 +1,3 @@
+output "firewall_policy" {
+  value = aws_networkfirewall_firewall_policy.policy
+}

--- a/modules/network-firewall-rules-egress/terraform-docs.yml
+++ b/modules/network-firewall-rules-egress/terraform-docs.yml
@@ -1,0 +1,41 @@
+formatter: markdown
+
+output:
+  file: README.md
+  mode: inject
+
+content: |
+  # Terraform Module for - network-firewall-rules-egress
+  # Example terragrunt.hcl inputs 
+  ```hcl
+  inputs = {
+    name        = "cc-egress-notprod-nfw-base-rules"
+    description = "cc-egress-notprod-nfw-base-rules"
+    account_id  = "example-aws-account-id"
+    vpc_id      = "vpc-example-id"
+    network_firewall_name = "cc-egress-notprod-nfw"
+    network_firewall_policy_name = "cc-egress-notprod-nfw-policy"
+    cidr_input  = "172.16.0.0/16"    
+    whitelisted_domains = file("./whitelisted-domains.txt")  
+    aws_managed_rule_groups = file("./aws_managed_rule_groups.txt")      
+    aws_region    = local.aws_region
+    tags = {
+      Name = "cc-networking-${get_env("env_name", "")}"
+    }
+  }
+  ```
+  {{ .Providers }}
+  {{ .Requirements }}
+  {{ .Resources }}
+  {{ .Inputs }}
+  {{ .Outputs }}
+  {{ .Footer }}
+settings:
+  sections:
+    - header
+    - providers
+    - requirements
+    - resources
+    - inputs
+    - outputs
+    - footer

--- a/modules/network-firewall-rules-egress/variables.tf
+++ b/modules/network-firewall-rules-egress/variables.tf
@@ -1,0 +1,41 @@
+# variables
+variable "tags" {
+  description = "Tags to apply to the resources."
+  type        = map(string)
+  default     = {}
+}
+
+variable "account_id" {
+  description = "Network Firewall Account-id"
+  type        = string
+}
+
+variable "network_firewall_name" {
+  description = "Network Firewall name to be supplied"
+  type        = string
+}
+
+variable "network_firewall_policy_name" {
+  description = "Network Firewall Policy name to be supplied"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC associated with Network Firewall"
+  type        = string
+}
+
+variable "home_net_cidr_ranges" {
+  description = "A set of CIDR ranges used fro the `HOME_NET` rule variable."
+  type        = set(string)
+}
+
+variable "whitelisted_domains" {
+  description = "Network Firewall - whitelisted domains file"
+  type        = string
+}
+
+variable "aws_managed_rule_groups" {
+  description = "Network Firewall - A list of AWS managed stateful rule group arns"
+  type        = string
+}

--- a/modules/network-firewall-rules-inspection/README.md
+++ b/modules/network-firewall-rules-inspection/README.md
@@ -1,0 +1,53 @@
+<!-- BEGIN_TF_DOCS -->
+# Terraform Module for - network-firewall-rules-inspection
+# Example terragrunt.hcl inputs 
+```hcl
+inputs = {
+  name        = "cc-inspection-notprod-nfw-base-rules"
+  description = "cc-inspection-notprod-nfw-base-rules"
+  account_id  = "example-aws-account-id"
+  vpc_id      = "vpc-example-id"
+  network_firewall_name = "cc-inspection-notprod-nfw"
+  network_firewall_policy_name = "cc-inspection-notprod-nfw-policy"
+  rules_file = file("./rules.txt") 
+  aws_managed_rule_groups = file("./aws_managed_rule_groups.txt")
+  aws_region    = local.aws_region
+  tags = {
+    Name = "cc-networking-${get_env("env_name", "")}"
+  }
+}
+```
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+## Requirements
+
+No requirements.
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_networkfirewall_firewall.existing_firewall](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_firewall) | resource |
+| [aws_networkfirewall_firewall_policy.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_firewall_policy) | resource |
+| [aws_networkfirewall_rule_group.main_rules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_rule_group) | resource |
+| [aws_networkfirewall_firewall.existing_firewall](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/networkfirewall_firewall) | data source |
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | Network Firewall Account-id | `string` | n/a | yes |
+| <a name="input_aws_managed_rule_groups"></a> [aws\_managed\_rule\_groups](#input\_aws\_managed\_rule\_groups) | Network Firewall - A list of AWS maanged stateful rule group arns | `string` | n/a | yes |
+| <a name="input_network_firewall_name"></a> [network\_firewall\_name](#input\_network\_firewall\_name) | Network Firewall name to be supplied | `string` | n/a | yes |
+| <a name="input_network_firewall_policy_name"></a> [network\_firewall\_policy\_name](#input\_network\_firewall\_policy\_name) | Network Firewall Policy name to be supplied | `string` | n/a | yes |
+| <a name="input_rules_file"></a> [rules\_file](#input\_rules\_file) | Network Firewall rules file | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to the resources. | `map(string)` | `{}` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC assocaited with Network Firewall | `string` | n/a | yes |
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_firewall_policy"></a> [firewall\_policy](#output\_firewall\_policy) | n/a |
+
+<!-- END_TF_DOCS -->

--- a/modules/network-firewall-rules-inspection/custom_firewall_rule_group.tf
+++ b/modules/network-firewall-rules-inspection/custom_firewall_rule_group.tf
@@ -1,0 +1,16 @@
+resource "aws_networkfirewall_rule_group" "main_rules" {
+  capacity = 5000
+  name     = "${var.network_firewall_name}-base-rules"
+  type     = "STATEFUL"
+
+  rule_group {
+    rules_source {
+      #rules_string = file("${path.module}/rules.txt")
+      rules_string = var.rules_file
+    }
+
+    stateful_rule_options {
+      rule_order = "STRICT_ORDER"
+    }
+  }
+}

--- a/modules/network-firewall-rules-inspection/main.tf
+++ b/modules/network-firewall-rules-inspection/main.tf
@@ -1,0 +1,88 @@
+############################################
+# Importing the existing network firewall  #
+############################################
+data "aws_networkfirewall_firewall" "existing_firewall" {
+  name = var.network_firewall_name   # "your-existing-firewall-name" imported using terragrunt as it was created using LZA
+}
+
+# Imported the existing NFW below as it was created using LZA
+# example:
+# terragrunt import aws_networkfirewall_firewall.existing_firewall arn:aws:network-firewall:eu-west-2:<aws-account-id>:firewall/<existing-firewal-name>
+import {
+  to = aws_networkfirewall_firewall.existing_firewall
+  id = "arn:aws:network-firewall:eu-west-2:${var.account_id}:firewall/${var.network_firewall_name}"
+}
+
+resource "aws_networkfirewall_firewall" "existing_firewall" {
+  name                = var.network_firewall_name # Existing firewall name
+  vpc_id              = var.vpc_id                # Use the existing VPC ID
+  firewall_policy_arn = aws_networkfirewall_firewall_policy.policy.arn
+
+  # Subnet mappings (use the existing subnets here)
+  dynamic "subnet_mapping" {
+    for_each = data.aws_networkfirewall_firewall.existing_firewall.subnet_mapping
+    content {
+      subnet_id = subnet_mapping.value.subnet_id
+    }
+  }
+  ## Keeping the old tags when it was created first time
+  tags = {
+    "Accelerator" = "AWSAccelerator"
+    "Name"        = var.network_firewall_name
+  }
+  # Add other necessary attributes here
+}
+
+################
+## nfw-policy" #
+################
+
+# Reading rule groups from text file supplied
+locals {
+  rule_group_arns = split("\n", trimspace(var.aws_managed_rule_groups))
+}
+
+resource "aws_networkfirewall_firewall_policy" "policy" {
+  name = var.network_firewall_policy_name
+
+  firewall_policy {
+    # Reference AWS managed or custom stateful rule groups
+
+    # Specify stateful default actions
+    stateful_default_actions = [
+      "aws:drop_established",     
+      "aws:alert_established"     
+    ]
+
+    # Configure stateful engine options
+    stateful_engine_options {
+      rule_order = "STRICT_ORDER"  # Options: "STRICT_ORDER" or "DEFAULT_ACTION_ORDER"
+    }
+
+    dynamic "stateful_rule_group_reference" {
+      for_each = local.rule_group_arns
+
+      content {
+        resource_arn = "arn:aws:network-firewall:eu-west-2:aws-managed:stateful-rulegroup/${stateful_rule_group_reference.value}"
+        priority     = 200 + index(local.rule_group_arns, stateful_rule_group_reference.value) + 1
+      }
+    }
+
+    # custom rules defined by core-cloud-platform
+    stateful_rule_group_reference {
+      resource_arn = aws_networkfirewall_rule_group.main_rules.arn
+      priority     = 250
+    }
+
+    # Define the stateless default actions explicitly
+    stateless_default_actions = ["aws:forward_to_sfe"]
+
+    # Define the stateless fragment default actions explicitly
+    stateless_fragment_default_actions = ["aws:forward_to_sfe"]
+  }
+
+  tags = {
+    Name = var.network_firewall_policy_name
+  }
+}
+

--- a/modules/network-firewall-rules-inspection/outputs.tf
+++ b/modules/network-firewall-rules-inspection/outputs.tf
@@ -1,0 +1,3 @@
+output "firewall_policy" {
+  value = aws_networkfirewall_firewall_policy.policy
+}

--- a/modules/network-firewall-rules-inspection/terraform-docs.yml
+++ b/modules/network-firewall-rules-inspection/terraform-docs.yml
@@ -1,0 +1,40 @@
+formatter: markdown
+
+output:
+  file: README.md
+  mode: inject
+
+content: |
+  # Terraform Module for - network-firewall-rules-inspection
+  # Example terragrunt.hcl inputs 
+  ```hcl
+  inputs = {
+    name        = "cc-inspection-notprod-nfw-base-rules"
+    description = "cc-inspection-notprod-nfw-base-rules"
+    account_id  = "example-aws-account-id"
+    vpc_id      = "vpc-example-id"
+    network_firewall_name = "cc-inspection-notprod-nfw"
+    network_firewall_policy_name = "cc-inspection-notprod-nfw-policy"
+    rules_file = file("./rules.txt") 
+    aws_managed_rule_groups = file("./aws_managed_rule_groups.txt")
+    aws_region    = local.aws_region
+    tags = {
+      Name = "cc-networking-${get_env("env_name", "")}"
+    }
+  }
+  ```
+  {{ .Providers }}
+  {{ .Requirements }}
+  {{ .Resources }}
+  {{ .Inputs }}
+  {{ .Outputs }}
+  {{ .Footer }}
+settings:
+  sections:
+    - header
+    - providers
+    - requirements
+    - resources
+    - inputs
+    - outputs
+    - footer

--- a/modules/network-firewall-rules-inspection/variables.tf
+++ b/modules/network-firewall-rules-inspection/variables.tf
@@ -1,0 +1,36 @@
+# variables
+variable "tags" {
+  description = "Tags to apply to the resources."
+  type        = map(string)
+  default     = {}
+}
+
+variable "account_id" {
+    description = "Network Firewall Account-id"
+    type        = string  
+}
+
+variable "network_firewall_name" {
+    description = "Network Firewall name to be supplied"
+    type        = string  
+}
+
+variable "network_firewall_policy_name" {
+    description = "Network Firewall Policy name to be supplied"
+    type        = string  
+}
+
+variable "vpc_id" {
+    description = "VPC assocaited with Network Firewall"
+    type        = string  
+}
+
+variable "rules_file" {
+    description = "Network Firewall rules file"
+    type        = string  
+}
+
+variable "aws_managed_rule_groups" {
+    description = "Network Firewall - A list of AWS maanged stateful rule group arns"
+    type        = string  
+}


### PR DESCRIPTION
This is for migrating the modules below from **core-cloud-terraform-modules** repo to this new repo, [core-cloud-firewall-terraform]

https://github.com/UKHomeOffice/core-cloud-terraform-modules//modules/aws/networking/network-firewall-rules-inspection?ref=3.9.0

https://github.com/UKHomeOffice/core-cloud-terraform-modules//modules/aws/networking/network-firewall-rules-egress?ref=3.9.0